### PR TITLE
IE9 Bug fix

### DIFF
--- a/jstorage.js
+++ b/jstorage.js
@@ -162,8 +162,10 @@
         /* Check if browser supports localStorage */
         if("localStorage" in window){
             try {
-                _storage_service = window.localStorage;
-                _backend = "localStorage";
+                if(window.localStorage) {
+                    _storage_service = window.localStorage;
+                    _backend = "localStorage";
+                }
             } catch(E3) {/* Firefox fails when touching localStorage and cookies are disabled */}
         }
         /* Check if browser supports globalStorage */


### PR DESCRIPTION
Your recent Firefox fix for disabled localStorage caused a new issue for disabled IE9 localStorage. This is just a little patch that works for both.

FYI - we are using jStorage in production on kongregate.com. Great little library. Thanks!
