### PR TITLE
Always extend window.$ before window.jQuery

### DIFF
--- a/jstorage.js
+++ b/jstorage.js
@@ -515,4 +515,4 @@
     // Initialize jStorage
     _init();
 
-})(window.jQuery || window.$);
+})(window.$ || window.jQuery);


### PR DESCRIPTION
I ran into a problem where, for one reason or another, multiple libraries were featured on the page, Protoype and jQuery.

Prototype was assigned to `$`, and jQuery was assigned to `$j`.

When initialising, jStorage checked for the presence of `window.jQuery`, discovered it was on the page, and proceeded to add the jStorage methods.  This meant that the methods had actually been assigned to `$j`, and not `$` causing 'method undefined' errors.

It's for this reason that I suggest attempting to bind to `window.$` first, then fall back to `window.jQuery` if it doesn't exist.

What do you think?
