### PR TITLE
Optimize MurmurHash for smaller filesize

### DIFF
--- a/jstorage.js
+++ b/jstorage.js
@@ -79,7 +79,7 @@
         _pubsub_observers = {},
 
         /* skip published items older than current timestamp */
-        _pubsub_last = +new Date(), 
+        _pubsub_last = +new Date(),
 
         /* Next check for TTL */
         _ttl_timeout,
@@ -256,7 +256,7 @@
     function _createPolyfillStorage(type, forceCreate){
         var _skipSave = false,
             _length = 0,
-            i, 
+            i,
             storage,
             storage_source = {};
 
@@ -272,7 +272,7 @@
             return;
         }
 
-        // only IE6/7 from this point on 
+        // only IE6/7 from this point on
         if(_backend != "userDataBehavior"){
             return;
         }
@@ -300,7 +300,7 @@
                 storage[i] = storage_source[i];
             }
         }
-        
+
         // Polyfill API
 
         /**
@@ -310,7 +310,7 @@
 
         /**
          * Returns the key of the nth stored value
-         * 
+         *
          * @param {Number} n Index position
          * @return {String} Key name of the nth stored value
          */
@@ -345,7 +345,7 @@
          * Sets or updates value for a give key
          *
          * @param {String} key Key name to be updated
-         * @param {String} value String value to be stored 
+         * @param {String} value String value to be stored
          */
         storage.setItem = function(key, value){
             if(typeof value == "undefined"){
@@ -365,7 +365,7 @@
             }
 
             storage[key] = undefined;
-            
+
             _skipSave = true;
             if(key in storage){
                 storage.removeAttribute(key);
@@ -783,7 +783,7 @@
         if(!_storage.__jstorage_meta.PubSub){
             _storage.__jstorage_meta.PubSub = [];
         }
-        
+
         _storage.__jstorage_meta.PubSub.unshift([+new Date, channel, payload]);
 
         _save();
@@ -795,54 +795,57 @@
      * JS Implementation of MurmurHash2
      *
      *  SOURCE: https://github.com/garycourt/murmurhash-js (MIT licensed)
-     * 
+     *
      * @author <a href="mailto:gary.court@gmail.com">Gary Court</a>
      * @see http://github.com/garycourt/murmurhash-js
      * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
      * @see http://sites.google.com/site/murmurhash/
-     * 
+     *
      * @param {string} str ASCII only
      * @param {number} seed Positive integer only
      * @return {number} 32-bit positive integer hash
      */
 
-    function murmurhash2_32_gc(str, seed) {
-        var
-            l = str.length,
-            h = seed ^ l,
-            i = 0,
-            k;
-      
-        while (l >= 4) {
-            k = 
-                ((str.charCodeAt(i) & 0xff)) |
-                ((str.charCodeAt(++i) & 0xff) << 8) |
-                ((str.charCodeAt(++i) & 0xff) << 16) |
-                ((str.charCodeAt(++i) & 0xff) << 24);
-        
-            k = (((k & 0xffff) * 0x5bd1e995) + ((((k >>> 16) * 0x5bd1e995) & 0xffff) << 16));
-            k ^= k >>> 24;
-            k = (((k & 0xffff) * 0x5bd1e995) + ((((k >>> 16) * 0x5bd1e995) & 0xffff) << 16));
+     function murmurhash2_32_gc(str, seed) {
+         var
+             l = str.length,
+             h = (seed || 0x9747b28c) ^ l,
+             i = 0,
+             k,
+             a = 0xff,
+             b = 0xffff,
+             c = 0x5bd1e995;
 
-            h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16)) ^ k;
+         while (l >= 4) {
+             k =
+                 ((str.charCodeAt(i) & a)) |
+                 ((str.charCodeAt(++i) & a) << 8) |
+                 ((str.charCodeAt(++i) & a) << 16) |
+                 ((str.charCodeAt(++i) & a) << 24);
 
-            l -= 4;
-            ++i;
-        }
-      
-        switch (l) {
-            case 3: h ^= (str.charCodeAt(i + 2) & 0xff) << 16;
-            case 2: h ^= (str.charCodeAt(i + 1) & 0xff) << 8;
-            case 1: h ^= (str.charCodeAt(i) & 0xff);
-                h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16));
-        }
+             k = (((k & b) * c) + ((((k >>> 16) * c) & b) << 16));
+             k ^= k >>> 24;
+             k = (((k & b) * c) + ((((k >>> 16) * c) & b) << 16));
 
-        h ^= h >>> 13;
-        h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16));
-        h ^= h >>> 15;
+             h = (((h & b) * c) + ((((h >>> 16) * c) & b) << 16)) ^ k;
 
-        return h >>> 0;
-    }
+             l -= 4;
+             ++i;
+       }
+
+         switch (l) {
+             case 3: h ^= (str.charCodeAt(i + 2) & a) << 16;
+             case 2: h ^= (str.charCodeAt(i + 1) & a) << 8;
+             case 1: h ^= (str.charCodeAt(i) & a);
+                     h = (((h & b) * c) + ((((h >>> 16) * c) & b) << 16));
+         }
+
+         h ^= h >>> 13;
+         h = (((h & b) * c) + ((((h >>> 16) * c) & b) << 16));
+         h ^= h >>> 15;
+
+         return h >>> 0;
+     }
 
     ////////////////////////// PUBLIC INTERFACE /////////////////////////
 
@@ -883,7 +886,7 @@
 
             _storage[key] = value;
 
-            _storage.__jstorage_meta.CRC32[key] = "2."+murmurhash2_32_gc(JSON.stringify(value), 0x9747b28c);
+            _storage.__jstorage_meta.CRC32[key] = "2."+murmurhash2_32_gc(JSON.stringify(value));
 
             this.setTTL(key, options.TTL || 0); // also handles saving and _publishChange
 


### PR DESCRIPTION
The constants inside MurmurHash are not minified even in the jStorage.min.js file. This patch will reduce the filesize by a few bytes.
