### PR TITLE
Fix Firefox's GlobalStorage not saving data when using localhost domain.

### DIFF
--- a/jstorage.js
+++ b/jstorage.js
@@ -176,6 +176,13 @@
         else if("globalStorage" in window){
             try {
                 if(window.globalStorage) {
+					if(window.location.hostname == 'localhost'){
+						var hostloc = 'localhost.localdomain';
+						_storage_service = window.globalStorage[hostloc];
+					}
+					else{
+						_storage_service = window.globalStorage[window.location.hostname];
+					}
                     _storage_service = window.globalStorage[window.location.hostname];
                     _backend = "globalStorage";
                     _observer_update = _storage_service.jStorage_update;


### PR DESCRIPTION
Firefox 2  and globalStorage have an issue where non dotted domains will not be accepted.
Using 'localhost.localdomain' as the host name is the recommended
solution.
