### PR TITLE
Fixed "QUOTA_EXCEEDED_ERR" exception in Safari when private mode was ena...

### DIFF
--- a/jstorage.js
+++ b/jstorage.js
@@ -392,7 +392,12 @@
         var updateTime = (+new Date()).toString();
 
         if(_backend == "localStorage" || _backend == "globalStorage"){
-            _storage_service.jStorage_update = updateTime;
+            try {
+                _storage_service.jStorage_update = updateTime;
+            } catch (E8) {
+                // safari private mode has been enabled after the jStorage initialization
+                _backend = null;
+            }
         }else if(_backend == "userDataBehavior"){
             _storage_elm.setAttribute("jStorage_update", updateTime);
             _storage_elm.save("jStorage");


### PR DESCRIPTION
...bled after the jStorage initialization has occurred.

The simplest solution I could come up with is setting the `_backend` to null, which will stop the QUOTA_EXCEEDED_ERR exception.

To reproduce the bug, you need to enable private mode in Safari after jStorage initialization has finished and then try to store data in it. It should throw QUOTA_EXCEEDED_ERR exception.
