### PR TITLE
Restore previous JSON check; 'in' will always be true here

### DIFF
--- a/jstorage.js
+++ b/jstorage.js
@@ -58,7 +58,7 @@
         };
 
     // Break if no JSON support was found
-    if (!('parse' in JSON) || !('stringify' in JSON)) {
+    if (!JSON.parse || !JSON.stringify) {
         throw new Error('No JSON support found, include //cdnjs.cloudflare.com/ajax/libs/json2/20110223/json2.js to page');
     }
 


### PR DESCRIPTION
The 'parse' and 'stringify' properties are always assigned in the literal,
so 'in' will evaluate to true.

Instead, check whether either value is falsy (which it will be if none of
the checked methods are available).

This restores the behavior prior to https://github.com/andris9/jStorage/commit/8c1bbfeb0997f6179fec0695df2815e53f68903b , which was correct.
