### PR TITLE
docs: Fix simple typo, numberic -> numeric

### DIFF
--- a/jstorage.js
+++ b/jstorage.js
@@ -470,7 +470,7 @@
     }
 
     /**
-     * Function checks if a key is set and is string or numberic
+     * Function checks if a key is set and is string or numeric
      *
      * @param {String} key Key name
      */


### PR DESCRIPTION
There is a small typo in jstorage.js.

Should read `numeric` rather than `numberic`.

